### PR TITLE
The web server configuration template

### DIFF
--- a/devops/static-nginx/default.conf.template
+++ b/devops/static-nginx/default.conf.template
@@ -74,7 +74,16 @@ server {
         root   /usr/share/nginx/html/;
         index  index.html index.htm;
     }
-
+    
+     location ~* \.(jpg|jpeg|gif|png|css|zip|tgz|gz|rar|bz2|doc|xls|pdf|ppt|tar|wav|bmp|rtf|swf|ico|flv|txt|xml|docx|xlsx)$ {
+        root   /usr/share/nginx/html/;
+        index  index.html index.htm;
+        access_log off;
+        expires 2m;
+        error_page 404 = @fallback;
+        proxy_cache_valid 404 1m;
+    }
+    
     location /pdf {
         expires max;
         root   /usr/share/nginx/html/;
@@ -122,5 +131,10 @@ server {
         proxy_pass      http://scylla;
         proxy_read_timeout 360s;
     }
-
+    location @fallback { 
+    proxy_pass http://127.0.0.1:80;  
+    proxy_set_header X-Real-IP $remote_addr; 
+    proxy_set_header X-Forwarded-for $remote_addr; 
+    proxy_set_header Host $host; 
+   }
 }


### PR DESCRIPTION
Added block locaton with modifier "~ *"
Added block locaton with modifier "@fallback" - If there is no image file, then nginx will not show a 404 error, but will redirect the request to the cryptic @fallback