### PR TITLE
Fix getUniqueCms

### DIFF
--- a/server/src/main/java/ua/papka24/server/security/CryptoManager.java
+++ b/server/src/main/java/ua/papka24/server/security/CryptoManager.java
@@ -494,7 +494,7 @@ public class CryptoManager {
         for (byte[] newCmsBytes : newCmsBytesList) {
             List<SignInfo> signInfos = CryptoniteX.cmsVerify(newCmsBytes);
 
-            if (digest != null && digest.length > 0 && !MessageDigest.isEqual(digest, signInfos.get(0).getHash())) {
+            if (digest != null && digest.length > 0 && !MessageDigest.isEqual(digest, swap(signInfos.get(0).getHash()))) {
                 continue;
             }
 


### PR DESCRIPTION
Не подписывалось из-за того, что байты в signInfos.getHash идут в обратном порядке...